### PR TITLE
Fix for subviews not resizing when using window snapping tool and fixing inconsistent state issue.

### DIFF
--- a/WAYSourceListWindow/WAYSourceListWindow.m
+++ b/WAYSourceListWindow/WAYSourceListWindow.m
@@ -194,18 +194,16 @@
 }
 
 #pragma mark - NSSplitView Delegate
-- (void)splitView:(NSSplitView *)sender resizeSubviewsWithOldSize:(NSSize)oldSize {
-	if ([self.splitView inLiveResize]) {
-		[self setNeedsLayout];
-	}
-}
-
 - (CGFloat) splitView:(NSSplitView *)splitView constrainMaxCoordinate:(CGFloat)proposedMaximumPosition ofSubviewAt:(NSInteger)dividerIndex {
 	return MIN(proposedMaximumPosition, self.maximumMasterViewWidth);
 }
 
 - (CGFloat) splitView:(NSSplitView *)splitView constrainMinCoordinate:(CGFloat)proposedMinimumPosition ofSubviewAt:(NSInteger)dividerIndex {
 	return MAX(proposedMinimumPosition, self.minimumMasterViewWidth);
+}
+
+- (BOOL) splitView:(NSSplitView *)splitView shouldAdjustSizeOfSubview:(NSView *)view {
+  return view == self.detailViewWrapper;
 }
 
 @end


### PR DESCRIPTION
Fixing issue where subview frames ended up in an inconsistent state (this was printing out to the console). Also changing the way resize is detected to fix issues with subviews sometimes not resizing.
